### PR TITLE
Fixnum & Integer unification for Ruby 2.4 compatibility

### DIFF
--- a/lib/daedal/attributes/query_value.rb
+++ b/lib/daedal/attributes/query_value.rb
@@ -4,7 +4,7 @@ module Daedal
     a string, a symbol, a float, or an integer. If it's none
     of those, raises a coercion error."""
     class QueryValue < Virtus::Attribute
-      ALLOWED_QUERY_VALUE_CLASSES = [String, Symbol, Float, Fixnum, Boolean, TrueClass, FalseClass]
+      ALLOWED_QUERY_VALUE_CLASSES = [String, Symbol, Float, 0.class, Boolean, TrueClass, FalseClass]
       def coerce(q)
         if !required? and q.nil?
           return q


### PR DESCRIPTION
This PR is to allow us to use Ruby 2.4 in our Rails app without deprecation warnings from the daedal gem.

This removes the deprecation warning `warning: constant ::Fixnum is deprecated`
