### PR TITLE
Add boost mode to function score query

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    daedal (0.0.17)
-      virtus (>= 1.0.0)
+    daedal (0.0.19)
+      virtus (~> 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +28,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
-    ffi (1.12.2)
+    ffi (1.15.4)
     formatador (0.2.4)
     fuubar (1.2.1)
       rspec (~> 2.0)
@@ -46,7 +46,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    ice_nine (0.11.1)
+    ice_nine (0.11.2)
     listen (2.4.0)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -88,17 +88,17 @@ GEM
     term-ansicolor (1.2.2)
       tins (~> 0.8)
     thor (0.18.1)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     timers (1.1.0)
     tins (0.13.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    virtus (1.0.2)
+    virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
-      descendants_tracker (~> 0.0.3)
-      equalizer (~> 0.0.9)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
 
 PLATFORMS
   ruby
@@ -110,3 +110,6 @@ DEPENDENCIES
   guard
   guard-rspec
   rspec
+
+BUNDLED WITH
+   2.2.28

--- a/daedal.gemspec
+++ b/daedal.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.homepage    =
     'https://github.com/cschuch/daedal'
 
-  s.add_dependency('virtus', '>= 1.0.0')
+  s.add_dependency('virtus', '~> 1.0.0')
 end

--- a/lib/daedal/attributes/lower_case_string.rb
+++ b/lib/daedal/attributes/lower_case_string.rb
@@ -1,7 +1,7 @@
 module Daedal
   module Attributes
     """Custom coercer for the type attribute"""
-    class LowerCaseString < Virtus::Attribute
+    class LowerCaseString < String
       def coerce(value)
         value = value.to_s
         if value.empty?

--- a/lib/daedal/queries/function_score_query.rb
+++ b/lib/daedal/queries/function_score_query.rb
@@ -10,6 +10,7 @@ module Daedal
       # non required attributes
       attribute :boost,           Daedal::Attributes::Boost,           required: false
       attribute :score_mode,      Daedal::Attributes::LowerCaseString, required: false
+      attribute :boost_mode,      Daedal::Attributes::LowerCaseString, required: false
       attribute :filter,          Daedal::Attributes::Filter,          required: false
 
       def to_hash
@@ -18,7 +19,8 @@ module Daedal
             query: build_query,
             functions: score_functions.map { |f| { filter: f[:filter]&.to_hash, weight: f[:weight], script_score: f[:script_score]&.to_hash }.compact! },
             boost: boost || 1,
-            score_mode: score_mode || "multiply"
+            score_mode: score_mode || "multiply",
+            boost_mode: boost_mode || "multiply"
           }
         }
       end

--- a/lib/daedal/version.rb
+++ b/lib/daedal/version.rb
@@ -1,3 +1,3 @@
 module Daedal
-  VERSION = '0.0.18'
+  VERSION = '0.0.19'
 end

--- a/spec/unit/daedal/queries/function_score_query_spec.rb
+++ b/spec/unit/daedal/queries/function_score_query_spec.rb
@@ -23,9 +23,9 @@ describe Daedal::Queries::FunctionScoreQuery do
     end
   end
 
-  context 'without a boost specified' do
-    it 'will raise an error' do
-      expect{ described_class.new(query: query, score_functions: score_functions) }.to raise_error(Virtus::CoercionError)
+  context 'without optional attributes' do
+    it 'will not raise an error' do
+      expect{ described_class.new(query: query, score_functions: score_functions) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
### What’s this do?
- Adds `boost_mode` to `FunctionScoreQuery` class and fixes optional `LowerCaseString` attributes.

### How should this be manually tested?
- Staging is using this branch, test with `boost_mode` by adding `mode=replace` to search params and without `boost_mode` by not adding this param (will fall back to default boost_mode).

### Related work
- https://github.com/flippa/flippa-rails/pull/8084

### Ticket
https://trello.com/c/4CAL44cw