### PR TITLE
Eng 10117 apply decay function on listing that have been outreached

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    daedal (0.0.19)
+    daedal (0.0.20)
       virtus (~> 1.0.0)
 
 GEM
@@ -91,9 +91,7 @@ GEM
     thread_safe (0.3.6)
     timers (1.1.0)
     tins (0.13.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.7)
+    unf (0.2.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -112,4 +110,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.2.28
+   2.4.17

--- a/lib/daedal.rb
+++ b/lib/daedal.rb
@@ -61,3 +61,4 @@ require 'daedal/queries/regexp_query'
 #functions
 require 'daedal/functions/function'
 require 'daedal/functions/script_score_function'
+require 'daedal/functions/decay_function'

--- a/lib/daedal/functions/decay_function.rb
+++ b/lib/daedal/functions/decay_function.rb
@@ -16,8 +16,8 @@ module Daedal
         {
           field => {
             origin: origin,
-            offset: offset,
             scale: scale,
+            offset: offset,
             decay: decay,
           }.compact
         }

--- a/lib/daedal/functions/decay_function.rb
+++ b/lib/daedal/functions/decay_function.rb
@@ -1,0 +1,27 @@
+module Daedal
+  module Functions
+    """Class for decay function"""
+    class DecayFunction < Function
+
+      # required attributes
+      attribute :field,  Daedal::Attributes::Field
+      attribute :origin, Daedal::Attributes::QueryValue
+      attribute :scale,  Daedal::Attributes::QueryValue
+
+      # non required attributes
+      attribute :offset, Daedal::Attributes::QueryValue, required: false
+      attribute :decay,  Daedal::Attributes::QueryValue, required: false
+
+      def to_hash
+        {
+          field => {
+            origin: origin,
+            offset: offset,
+            scale: scale,
+            decay: decay,
+          }.compact
+        }
+      end
+    end
+  end
+end

--- a/lib/daedal/queries/function_score_query.rb
+++ b/lib/daedal/queries/function_score_query.rb
@@ -17,7 +17,7 @@ module Daedal
         {
           function_score: {
             query: build_query,
-            functions: score_functions.map { |sf| sanitize_score_function(sf) },
+            functions: score_functions.map { |sf| build_score_function(sf) },
             boost: boost || 1,
             score_mode: score_mode || "multiply",
             boost_mode: boost_mode || "multiply"
@@ -35,7 +35,7 @@ module Daedal
         end
       end
 
-      def sanitize_score_function(sf)
+      def build_score_function(sf)
         {
           filter: sf[:filter]&.to_hash,
           weight: sf[:weight],

--- a/lib/daedal/queries/function_score_query.rb
+++ b/lib/daedal/queries/function_score_query.rb
@@ -17,7 +17,7 @@ module Daedal
         {
           function_score: {
             query: build_query,
-            functions: score_functions.map { |sf| build_score_function(sf) },
+            functions: score_functions.map { |score_function| build_score_function(score_function) },
             boost: boost || 1,
             score_mode: score_mode || "multiply",
             boost_mode: boost_mode || "multiply"
@@ -35,15 +35,15 @@ module Daedal
         end
       end
 
-      def build_score_function(sf)
+      def build_score_function(score_function)
         {
-          filter: sf[:filter]&.to_hash,
-          weight: sf[:weight],
-          script_score: sf[:script_score]&.to_hash,
-          gauss: sf[:gauss]&.to_hash,
-          exp: sf[:exp]&.to_hash,
-          linear: sf[:linear]&.to_hash,
-        }.compact!
+          filter: score_function[:filter]&.to_hash,
+          weight: score_function[:weight],
+          script_score: score_function[:script_score]&.to_hash,
+          gauss: score_function[:gauss]&.to_hash,
+          exp: score_function[:exp]&.to_hash,
+          linear: score_function[:linear]&.to_hash,
+        }.compact
       end
     end
   end

--- a/lib/daedal/queries/function_score_query.rb
+++ b/lib/daedal/queries/function_score_query.rb
@@ -17,7 +17,7 @@ module Daedal
         {
           function_score: {
             query: build_query,
-            functions: score_functions.map { |f| { filter: f[:filter]&.to_hash, weight: f[:weight], script_score: f[:script_score]&.to_hash }.compact! },
+            functions: score_functions.map { |sf| sanitize_score_function(sf) },
             boost: boost || 1,
             score_mode: score_mode || "multiply",
             boost_mode: boost_mode || "multiply"
@@ -33,6 +33,17 @@ module Daedal
         else
           query.to_hash
         end
+      end
+
+      def sanitize_score_function(sf)
+        {
+          filter: sf[:filter]&.to_hash,
+          weight: sf[:weight],
+          script_score: sf[:script_score]&.to_hash,
+          gauss: sf[:gauss]&.to_hash,
+          exp: sf[:exp]&.to_hash,
+          linear: sf[:linear]&.to_hash,
+        }.compact!
       end
     end
   end

--- a/lib/daedal/version.rb
+++ b/lib/daedal/version.rb
@@ -1,3 +1,3 @@
 module Daedal
-  VERSION = '0.0.19'
+  VERSION = '0.0.20'
 end

--- a/spec/unit/daedal/functions/decay_function_spec.rb
+++ b/spec/unit/daedal/functions/decay_function_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe Daedal::Functions::DecayFunction do
+  subject { described_class }
+
+  describe "#to_hash" do
+    context "without the required arguments" do
+      it "will raise an error" do
+        expect{subject.new.to_hash}.to raise_error(Virtus::CoercionError)
+      end
+    end
+
+    context "with the minimal valid arguments" do
+      let(:expected_hash) do
+        {
+          my_field: {
+            origin: "now",
+            scale: "2d"
+          }
+        }
+      end
+
+      it "builds the decay function hash" do
+        expect(subject.new(field: :my_field, origin: "now", scale: "2d").to_hash).to eq(expected_hash)
+      end
+    end
+
+    context "with all valid arguments" do
+      let(:expected_hash) do
+        {
+          my_field: {
+            origin: "now-8d",
+            scale: "3d",
+            offset: "4d",
+            decay: 0.36
+          }
+        }
+      end
+
+      it "builds the decay function hash" do
+        expect(subject.new(field: :my_field, origin: "now-8d", scale: "3d", offset: "4d", decay: 0.36).to_hash).to eq(expected_hash)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What's this do?
- Allows `gauss`, `exp` and `linear` decay functions in score functions.
- Creates a new `DecayFunction` class and specs.
- Updates gem version.

### Example usage:

```rb
score_query = SearchV2::Queries::FunctionScoreQuery.new(
  query: filtered_query,
  score_functions: [
    {
      filter: Flippa::SearchV2::Filters::RangeFilter.new(field: :decay_outreached_at, gte: "now-14d/d"),
      gauss: Daedal::Functions::DecayFunction.new(field: :decay_outreached_at, origin: "now", scale: "14d", decay: 0.25)
    }
  ]
)
```